### PR TITLE
Fixed error when sending pushes to one pushType

### DIFF
--- a/src/ParsePushAdapter.js
+++ b/src/ParsePushAdapter.js
@@ -50,19 +50,22 @@ export class ParsePushAdapter {
     for (let pushType in deviceMap) {
       let sender = this.senderMap[pushType];
       let devices = deviceMap[pushType];
-      if (!sender) {
-        log.verbose(LOG_PREFIX, `Can not find sender for push type ${pushType}, ${data}`)
-        let results = devices.map((device) => {
-          return Promise.resolve({
-            device,
-            transmitted: false,
-            response: {'error': `Can not find sender for push type ${pushType}, ${data}`}
-          })
-        });
-        sendPromises.push(Promise.all(results));
-      } else {
-        sendPromises.push(sender.send(data, devices));
-      }
+	  if(devices.length > 0)
+	  {
+		  if (!sender) {
+			log.verbose(LOG_PREFIX, `Can not find sender for push type ${pushType}, ${data}`)
+			let results = devices.map((device) => {
+			  return Promise.resolve({
+				device,
+				transmitted: false,
+				response: {'error': `Can not find sender for push type ${pushType}, ${data}`}
+			  })
+			});
+			sendPromises.push(Promise.all(results));
+		  } else {
+			sendPromises.push(sender.send(data, devices));
+		  }
+	  }
     }
     return Promise.all(sendPromises).then((promises) => {
       // flatten all

--- a/src/ParsePushAdapter.js
+++ b/src/ParsePushAdapter.js
@@ -50,22 +50,22 @@ export class ParsePushAdapter {
     for (let pushType in deviceMap) {
       let sender = this.senderMap[pushType];
       let devices = deviceMap[pushType];
-	  if(devices.length > 0)
-	  {
-		  if (!sender) {
-			log.verbose(LOG_PREFIX, `Can not find sender for push type ${pushType}, ${data}`)
-			let results = devices.map((device) => {
-			  return Promise.resolve({
-				device,
-				transmitted: false,
-				response: {'error': `Can not find sender for push type ${pushType}, ${data}`}
-			  })
-			});
-			sendPromises.push(Promise.all(results));
-		  } else {
-			sendPromises.push(sender.send(data, devices));
-		  }
-	  }
+      if(Array.isArray(devices) && devices.length > 0)
+      {
+        if (!sender) {
+          log.verbose(LOG_PREFIX, `Can not find sender for push type ${pushType}, ${data}`)
+          let results = devices.map((device) => {
+            return Promise.resolve({
+              device,
+              transmitted: false,
+              response: {'error': `Can not find sender for push type ${pushType}, ${data}`}
+            })
+          });
+          sendPromises.push(Promise.all(results));
+        } else {
+          sendPromises.push(sender.send(data, devices));
+        }
+      }
     }
     return Promise.all(sendPromises).then((promises) => {
       // flatten all


### PR DESCRIPTION
Added check for empty devices sets when sending push notifications to
senders. This fixes and issue where the empty sets being processed by
the senders would throw several reference errors.

Fixes  ParsePlatform/parse-server#1245