### PR TITLE
APNS expects expiration time to be in seconds, not MS.

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -84,7 +84,7 @@ describe('APNS', () => {
       'key': 'value',
       'keyAgain': 'valueAgain'
     });
-    expect(notification.expiry).toEqual(expirationTime);
+    expect(notification.expiry).toEqual(expirationTime/1000);
     done();
   });
 
@@ -298,7 +298,7 @@ describe('APNS', () => {
     var args = conn.pushNotification.calls.first().args;
     var notification = args[0];
     expect(notification.alert).toEqual(data.data.alert);
-    expect(notification.expiry).toEqual(data['expiration_time']);
+    expect(notification.expiry).toEqual(data['expiration_time']/1000);
     var apnDevice = args[1]
     expect(apnDevice.connIndex).toEqual(0);
     expect(apnDevice.appIdentifier).toEqual('bundleId');

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -201,6 +201,7 @@ function chooseConns(conns, device) {
 /**
  * Generate the apns notification from the data we get from api request.
  * @param {Object} coreData The data field under api request body
+ * @param {number} expirationTime The expiration time in milliseconds since Jan 1 1970
  * @returns {Object} A apns notification
  */
 function generateNotification(coreData, expirationTime) {
@@ -231,7 +232,7 @@ function generateNotification(coreData, expirationTime) {
     }
   }
   notification.payload = payload;
-  notification.expiry = expirationTime;
+  notification.expiry = expirationTime / 1000;
   return notification;
 }
 


### PR DESCRIPTION
parse-server expresses epoch time in milliseconds, while APNS expects it to be in seconds.
This causes parse-server (when correctly configured to send to APNS) to crash when the following cloud code is executed:

```
Parse.Cloud.define("testPush", function(request, response) {
    var query = new Parse.Query(Parse.Installation);
    query.equalTo( <query...> );

    var today = new Date();
    var timeout = new Date(today.getFullYear(), today.getMonth(), today.getDay() + 1);

    Parse.Push.send({
        where: query,
        expiration_time: timeout,
        data: {alert: "push hello"},
    }, {
        useMasterKey: true,
        success: response.success,
        error: response.error,
    });
});
```

with the error:

```
verbose: sending push to 69 installations
verb parse-server-push-adapter APNS APNS Connection 0 Connected
verb parse-server-push-adapter APNS APNS Connection 1 Connected
/parse-server/node_modules/parse-server/lib/ParseServer.js:333
            throw err;
            ^

TypeError: value is out of bounds
    at checkInt (buffer.js:971:11)
    at Buffer.writeUInt32BE (buffer.js:1064:5)
    at Connection.transmitNotification (/parse-server/node_modules/apn/lib/connection.js:691:8)
    at Connection.serviceBuffer (/parse-server/node_modules/apn/lib/connection.js:330:13)
    at Connection.<anonymous> (/parse-server/node_modules/apn/lib/connection.js:287:8)
    at Promise.apply (/parse-server/node_modules/q/q.js:1165:26)
    at Promise.promise.promiseDispatch (/parse-server/node_modules/q/q.js:788:41)
    at /parse-server/node_modules/q/q.js:1391:14
    at runSingle (/parse-server/node_modules/q/q.js:137:13)
    at flush (/Users parse-server/node_modules/q/q.js:125:13)

npm ERR! Darwin 15.4.0
npm ERR! argv "/usr/local/Cellar/node/5.10.0/bin/node" "/usr/local/bin/npm" "start"
npm ERR! node v5.10.0
npm ERR! npm  v3.8.3
npm ERR! code ELIFECYCLE
npm ERR! parse-server@0.1.0 start: `node index.js`
npm ERR! Exit status 7
npm ERR! 
npm ERR! Failed at the parse-server@0.1.0 start script 'node index.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the parse-server package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node index.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs parse-server
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls parse-server
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /parse-server/npm-debug.log
```

This patch converts the time sent to APNS from MS to seconds.
