### PR TITLE
Support `mutable-content`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jasmine": "^2.4.1"
   },
   "dependencies": {
-    "apn": "^1.7.5",
+    "apn": "^1.7.8",
     "node-gcm": "^0.14.0",
     "npmlog": "^2.0.3",
     "parse": "^1.8.1"

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -67,6 +67,7 @@ describe('APNS', () => {
       'badge': 100,
       'sound': 'test',
       'content-available': 1,
+      'mutable-content': 1,
       'category': 'INVITE_CATEGORY',
       'key': 'value',
       'keyAgain': 'valueAgain'
@@ -79,6 +80,7 @@ describe('APNS', () => {
     expect(notification.badge).toEqual(data.badge);
     expect(notification.sound).toEqual(data.sound);
     expect(notification.contentAvailable).toEqual(1);
+    expect(notification.mutableContent).toEqual(1);
     expect(notification.category).toEqual(data.category);
     expect(notification.payload).toEqual({
       'key': 'value',

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -236,6 +236,10 @@ function generateNotification(coreData, expirationTime) {
         let isAvailable = coreData['content-available'] === 1;
         notification.setContentAvailable(isAvailable);
         break;
+      case 'mutable-content':
+        let isMutable = coreData['mutable-content'] === 1;
+        notification.setMutableContent(isMutable);
+        break;
       case 'category':
         notification.category = coreData.category;
         break;


### PR DESCRIPTION
In iOS 10, remote notification payloads can be mutated on the client before presentation to the user, allowing for rich content to be displayed (images, video).

The key to this is a mutable-content boolean value in the payload that must be set to 1.

I have added support for mutable-content, along with a test, and updated the `apn` dependency.

Further information in the WWDC presentation (page 16): http://devstreaming.apple.com/videos/wwdc/2016/708tbh8wnspsg01hxwx/708/708_advanced_notifications.pdf