### PR TITLE
Added notification field for fcm [WIP]

### DIFF
--- a/spec/GCM.spec.js
+++ b/spec/GCM.spec.js
@@ -35,13 +35,13 @@ describe('GCM', () => {
 
     var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp);
 
-    expect(payload.priority).toEqual('normal');
+    expect(payload.priority).toEqual('high');
     expect(payload.timeToLive).toEqual(undefined);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
     expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
-    var dataFromUser = JSON.parse(dataFromPayload.data);
+    var dataFromUser = dataFromPayload.data;
     expect(dataFromUser).toEqual(requestData.data);
     done();
   });
@@ -64,13 +64,13 @@ describe('GCM', () => {
 
     var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
-    expect(payload.priority).toEqual('normal');
+    expect(payload.priority).toEqual('high');
     expect(payload.timeToLive).toEqual(Math.floor((expirationTime - timeStamp) / 1000));
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
     expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
-    var dataFromUser = JSON.parse(dataFromPayload.data);
+    var dataFromUser = dataFromPayload.data;
     expect(dataFromUser).toEqual(requestData.data);
     done();
   });
@@ -93,13 +93,13 @@ describe('GCM', () => {
 
     var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
-    expect(payload.priority).toEqual('normal');
+    expect(payload.priority).toEqual('high');
     expect(payload.timeToLive).toEqual(0);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
     expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
-    var dataFromUser = JSON.parse(dataFromPayload.data);
+    var dataFromUser = dataFromPayload.data;
     expect(dataFromUser).toEqual(requestData.data);
     done();
   });
@@ -122,14 +122,14 @@ describe('GCM', () => {
 
     var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
-    expect(payload.priority).toEqual('normal');
+    expect(payload.priority).toEqual('high');
     // Four week in second
     expect(payload.timeToLive).toEqual(4 * 7 * 24 * 60 * 60);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
     expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
-    var dataFromUser = JSON.parse(dataFromPayload.data);
+    var dataFromUser = dataFromPayload.data;
     expect(dataFromUser).toEqual(requestData.data);
     done();
   });

--- a/spec/GCM.spec.js
+++ b/spec/GCM.spec.js
@@ -20,89 +20,117 @@ describe('GCM', () => {
 
   it('can generate GCM Payload without expiration time', (done) => {
     //Mock request data
-    var data = {
-      'alert': 'alert'
+    var requestData = {
+      data: {
+        'alert': 'alert'
+      },
+      notification: {
+        'title': 'I am a title',
+        'body': 'I am a body'
+      }
     };
     var pushId = 'pushId';
     var timeStamp = 1454538822113;
     var timeStampISOStr = new Date(timeStamp).toISOString();
 
-    var payload = GCM.generateGCMPayload(data, pushId, timeStamp);
+    var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp);
 
     expect(payload.priority).toEqual('normal');
     expect(payload.timeToLive).toEqual(undefined);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
+    expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
     var dataFromUser = JSON.parse(dataFromPayload.data);
-    expect(dataFromUser).toEqual(data);
+    expect(dataFromUser).toEqual(requestData.data);
     done();
   });
 
   it('can generate GCM Payload with valid expiration time', (done) => {
     //Mock request data
-    var data = {
-      'alert': 'alert'
+    var requestData = {
+      data: {
+        'alert': 'alert'
+      },
+      notification: {
+        'title': 'I am a title',
+        'body': 'I am a body'
+      }
     };
     var pushId = 'pushId';
     var timeStamp = 1454538822113;
     var timeStampISOStr = new Date(timeStamp).toISOString();
     var expirationTime = 1454538922113
 
-    var payload = GCM.generateGCMPayload(data, pushId, timeStamp, expirationTime);
+    var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
     expect(payload.priority).toEqual('normal');
     expect(payload.timeToLive).toEqual(Math.floor((expirationTime - timeStamp) / 1000));
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
+    expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
     var dataFromUser = JSON.parse(dataFromPayload.data);
-    expect(dataFromUser).toEqual(data);
+    expect(dataFromUser).toEqual(requestData.data);
     done();
   });
 
   it('can generate GCM Payload with too early expiration time', (done) => {
     //Mock request data
-    var data = {
-      'alert': 'alert'
+    var requestData = {
+      data: {
+        'alert': 'alert'
+      },
+      notification: {
+        'title': 'I am a title',
+        'body': 'I am a body'
+      }
     };
     var pushId = 'pushId';
     var timeStamp = 1454538822113;
     var timeStampISOStr = new Date(timeStamp).toISOString();
     var expirationTime = 1454538822112;
 
-    var payload = GCM.generateGCMPayload(data, pushId, timeStamp, expirationTime);
+    var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
     expect(payload.priority).toEqual('normal');
     expect(payload.timeToLive).toEqual(0);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
+    expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
     var dataFromUser = JSON.parse(dataFromPayload.data);
-    expect(dataFromUser).toEqual(data);
+    expect(dataFromUser).toEqual(requestData.data);
     done();
   });
 
   it('can generate GCM Payload with too late expiration time', (done) => {
     //Mock request data
-    var data = {
-      'alert': 'alert'
+    var requestData = {
+      data: {
+        'alert': 'alert'
+      },
+      notification: {
+        'title': 'I am a title',
+        'body': 'I am a body'
+      }
     };
     var pushId = 'pushId';
     var timeStamp = 1454538822113;
     var timeStampISOStr = new Date(timeStamp).toISOString();
     var expirationTime = 2454538822113;
 
-    var payload = GCM.generateGCMPayload(data, pushId, timeStamp, expirationTime);
+    var payload = GCM.generateGCMPayload(requestData, pushId, timeStamp, expirationTime);
 
     expect(payload.priority).toEqual('normal');
     // Four week in second
     expect(payload.timeToLive).toEqual(4 * 7 * 24 * 60 * 60);
     var dataFromPayload = payload.data;
     expect(dataFromPayload.time).toEqual(timeStampISOStr);
+    expect(payload.notification).toEqual(requestData.notification);
     expect(dataFromPayload['push_id']).toEqual(pushId);
     var dataFromUser = JSON.parse(dataFromPayload.data);
-    expect(dataFromUser).toEqual(data);
+    expect(dataFromUser).toEqual(requestData.data);
     done();
   });
 

--- a/spec/ParsePushAdapter.spec.js
+++ b/spec/ParsePushAdapter.spec.js
@@ -54,13 +54,13 @@ describe('ParsePushAdapter', () => {
   it('can get valid push types', (done) => {
     var parsePushAdapter = new ParsePushAdapter();
 
-    expect(parsePushAdapter.getValidPushTypes()).toEqual(['ios', 'android']);
+    expect(parsePushAdapter.getValidPushTypes()).toEqual(['ios', 'android', 'fcm']);
     done();
   });
 
   it('can classify installation', (done) => {
     // Mock installations
-    var validPushTypes = ['ios', 'android'];
+    var validPushTypes = ['ios', 'android', 'fcm'];
     var installations = [
       {
         deviceType: 'android',

--- a/src/GCM.js
+++ b/src/GCM.js
@@ -57,7 +57,7 @@ GCM.prototype.send = function(data, devices) {
   }
   // Generate gcm payload
   // PushId is not a formal field of GCM, but Parse Android SDK uses this field to deduplicate push notifications
-  let gcmPayload = generateGCMPayload(data.data, pushId, timestamp, expirationTime);
+  let gcmPayload = generateGCMPayload(data, pushId, timestamp, expirationTime);
   // Make and send gcm request
   let message = new gcm.Message(gcmPayload);
 
@@ -120,16 +120,18 @@ GCM.prototype.send = function(data, devices) {
  * @param {Number|undefined} expirationTime A number whose format is the Unix Epoch or undefined
  * @returns {Object} A promise which is resolved after we get results from gcm
  */
-function generateGCMPayload(coreData, pushId, timeStamp, expirationTime) {
-  let payloadData =  {
-    'time': new Date(timeStamp).toISOString(),
-    'push_id': pushId,
-    'data': JSON.stringify(coreData)
-  }
+function generateGCMPayload(requestData, pushId, timeStamp, expirationTime) {
   let payload = {
-    priority: 'normal',
-    data: payloadData
+    priority: 'normal'
   };
+  payload.data = {
+    data: JSON.stringify(requestData.data),
+    push_id: pushId,
+    time: new Date(timeStamp).toISOString()
+  }
+  if (requestData.notification) {
+    payload.notification = requestData.notification;
+  }
   if (expirationTime) {
    // The timeStamp and expiration is in milliseconds but gcm requires second
     let timeToLive = Math.floor((expirationTime - timeStamp) / 1000);

--- a/src/GCM.js
+++ b/src/GCM.js
@@ -114,7 +114,7 @@ GCM.prototype.send = function(data, devices) {
 
 /**
  * Generate the gcm payload from the data we get from api request.
- * @param {Object} coreData The data field under api request body
+ * @param {Object} requestData The request body
  * @param {String} pushId A random string
  * @param {Number} timeStamp A number whose format is the Unix Epoch
  * @param {Number|undefined} expirationTime A number whose format is the Unix Epoch or undefined
@@ -122,12 +122,15 @@ GCM.prototype.send = function(data, devices) {
  */
 function generateGCMPayload(requestData, pushId, timeStamp, expirationTime) {
   let payload = {
-    priority: 'normal'
+    priority: 'high'
   };
   payload.data = {
-    data: JSON.stringify(requestData.data),
+    data: requestData.data,
     push_id: pushId,
     time: new Date(timeStamp).toISOString()
+  }
+  if (requestData.content_available) {
+    payload.content_available = requestData.content_available;
   }
   if (requestData.notification) {
     payload.notification = requestData.notification;

--- a/src/ParsePushAdapter.js
+++ b/src/ParsePushAdapter.js
@@ -12,7 +12,7 @@ export class ParsePushAdapter {
   supportsPushTracking = true;
 
   constructor(pushConfig = {}) {
-    this.validPushTypes = ['ios', 'android'];
+    this.validPushTypes = ['ios', 'android', 'fcm'];
     this.senderMap = {};
     // used in PushController for Dashboard Features
     this.feature = {
@@ -30,6 +30,7 @@ export class ParsePushAdapter {
           this.senderMap[pushType] = new APNS(pushConfig[pushType]);
           break;
         case 'android':
+        case 'fcm':
           this.senderMap[pushType] = new GCM(pushConfig[pushType]);
           break;
       }


### PR DESCRIPTION
Related to #32.  
You should be able to send notifications this way:
```
POST /api/push HTTP/1.1
Host: localhost:1337
X-Parse-Application-Id: TEST_APP_ID
X-Parse-Master-Key: TEST_MASTER_KEY
Content-Type: application/json
Cache-Control: no-cache
Postman-Token: 277e9e75-565d-1a81-b80b-1575809fbac6

{
    "where": {
	    "objectId" : "yTgONHk2il"
    },
    "data": {
        "data" : "Hello World!"
    },
    "notification": {
    	"title": "I am a title",
    	"body": "I am the body"
    }
}
```  

Why do you need a notification field?
Because with the recent gcm -> fcm migration the notification field is required for showing the notification when the app is in background.
```javascript
// push adapter config
  push: {
    fcm: {
      senderId: keys.FCM_SENDER_ID,
      apiKey: keys.FCM_API_KEY
    }
  }
```

From my testing it works on both Android and iOS.