### PR TITLE
Fixed link for Parse-server push configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Status](https://travis-ci.org/parse-server-modules/parse-server-push-adapter.svg
 
 Official Push adapter for parse-server
 
-See [parse-server push configuration](https://github.com/ParsePlatform/parse-server/wiki/Push)
+See [parse-server push configuration](http://parseplatform.github.io/docs/parse-server/guide/#push-notifications)
 
 ## Silent Notifications
 


### PR DESCRIPTION
The old parse server push configuration link https://github.com/ParsePlatform/parse-server/wiki/Push is broken. New link for the guide is here: http://parseplatform.github.io/docs/parse-server/guide/#push-notifications