### PR TITLE
fix error message

### DIFF
--- a/src/ParsePushAdapter.js
+++ b/src/ParsePushAdapter.js
@@ -23,7 +23,7 @@ export class ParsePushAdapter {
     for (let pushType of pushTypes) {
       if (this.validPushTypes.indexOf(pushType) < 0) {
         throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
-                              'Push to ' + pushTypes + ' is not supported');
+                              'Push to ' + pushType + ' is not supported');
       }
       switch (pushType) {
         case 'ios':


### PR DESCRIPTION
This is just a tiny little fix. The error message should print the unsupported push type instead of the array of supported push types.