### PR TITLE
Update APNS.js - Add iOS Notification Title

### DIFF
--- a/src/APNS.js
+++ b/src/APNS.js
@@ -176,6 +176,9 @@ export class APNS {
         case 'alert':
           notification.setAlert(coreData.alert);
           break;
+        case 'title':
+          notification.setAlertTitle(coreData.title);
+        break;
         case 'badge':
           notification.setBadge(coreData.badge);
           break;


### PR DESCRIPTION
As of iOS 8.2 Apple added the ability to send a "title" attribute with notifications.
APNS notification can now look like this:
 {   
     "aps": {
            "alert": {
                "title": "notification_title",
                "body": "notification_content"
            }
        },
        User-defined key-value pairs
 }

Therefore sending a title attribute with Parse-Push on iOS need to be added within the "alert" statement and not the "User-defined key-value pairs" to be properly displayed by iOS devices.