### PR TITLE
Add support for passing collapse-id to APNS

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -169,8 +169,9 @@ describe('APNS', () => {
       'keyAgain': 'valueAgain'
     };
     let expirationTime = 1454571491354;
+    let collapseId = "collapseIdentifier";
 
-    let notification = APNS._generateNotification(data, expirationTime);
+    let notification = APNS._generateNotification(data, { expirationTime: expirationTime, collapseId: collapseId });
 
     expect(notification.aps.alert).toEqual(data.alert);
     expect(notification.aps.badge).toEqual(data.badge);
@@ -183,6 +184,7 @@ describe('APNS', () => {
       'keyAgain': 'valueAgain'
     });
     expect(notification.expiry).toEqual(expirationTime / 1000);
+    expect(notification.collapseId).toEqual(collapseId);
     done();
   });
 
@@ -239,7 +241,9 @@ describe('APNS', () => {
     });
     // Mock data
     let expirationTime = 1454571491354;
+    let collapseId = "collapseIdentifier";
     let data = {
+      'collapse_id': collapseId,
       'expiration_time': expirationTime,
       'data': {
         'alert': 'alert'
@@ -270,6 +274,7 @@ describe('APNS', () => {
     let notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
     expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.collapseId).toEqual(data['collapse_id']);
     let apnDevices = calledArgs[1];
     expect(apnDevices.length).toEqual(4);
     done();
@@ -306,7 +311,9 @@ describe('APNS', () => {
     apns.providers = [provider, providerDev];
     // Mock data
     let expirationTime = 1454571491354;
+    let collapseId = "collapseIdentifier";
     let data = {
+      'collapse_id': collapseId,
       'expiration_time': expirationTime,
       'data': {
         'alert': 'alert'
@@ -343,6 +350,7 @@ describe('APNS', () => {
     let notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
     expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.collapseId).toEqual(data['collapse_id']);
     let apnDevices = calledArgs[1];
     expect(apnDevices.length).toBe(3);
 
@@ -351,6 +359,7 @@ describe('APNS', () => {
     notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
     expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.collapseId).toEqual(data['collapse_id']);
     apnDevices = calledArgs[1];
     expect(apnDevices.length).toBe(2);
     done();

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -96,7 +96,7 @@ export class APNS {
         continue;
       }
 
-      let headers = { expirationTime: expirationTime, appIdentifier: appIdentifier, collapseId: collapseId }
+      let headers = { expirationTime: expirationTime, topic: appIdentifier, collapseId: collapseId }
       let notification = APNS._generateNotification(coreData, headers);
       const deviceIds = devices.map(device => device.deviceToken);
       let promise = this.sendThroughProvider(notification, deviceIds, providers);

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -72,6 +72,7 @@ export class APNS {
   send(data, allDevices) {
     let coreData = data.data;
     let expirationTime = data['expiration_time'];
+    let collapseId = data['collapse_id'];
     let allPromises = [];
 
     let devicesPerAppIdentifier = {};
@@ -95,7 +96,8 @@ export class APNS {
         continue;
       }
 
-      let notification = APNS._generateNotification(coreData, expirationTime, appIdentifier);
+      let headers = { expirationTime: expirationTime, appIdentifier: appIdentifier, collapseId: collapseId }
+      let notification = APNS._generateNotification(coreData, headers);
       const deviceIds = devices.map(device => device.deviceToken);
       let promise = this.sendThroughProvider(notification, deviceIds, providers);
       allPromises.push(promise.then(this._handlePromise.bind(this)));
@@ -164,11 +166,10 @@ export class APNS {
   /**
    * Generate the apns Notification from the data we get from api request.
    * @param {Object} coreData The data field under api request body
-   * @param {number} expirationTime The expiration time in milliseconds since Jan 1 1970
-   * @param {String} topic Topic the Notification is sent to
+   * @param {Object} headers The header properties for the notification (topic, expirationTime, collapseId)
    * @returns {Object} A apns Notification
    */
-  static _generateNotification(coreData, expirationTime, topic) {
+  static _generateNotification(coreData, headers) {
     let notification = new apn.Notification();
     let payload = {};
     for (let key in coreData) {
@@ -198,9 +199,12 @@ export class APNS {
           break;
       }
     }
-    notification.topic = topic;
+
     notification.payload = payload;
-    notification.expiry = expirationTime / 1000;
+
+    notification.topic = headers.topic;
+    notification.expiry = headers.expirationTime / 1000;
+    notification.collapseId = headers.collapseId;
     return notification;
   }
 


### PR DESCRIPTION
Added support for adding `apns-collapse-id` to enable collapsing of pushes just like the `apns-expiration`.

I changed the method signature for `APNS_generateNotification` from `APNS._generateNotification(data, expirationDate)` to `APNS._generateNotification(data, headers)` making it easier to add more header properties in the future.

# headers
The headers parameter is a JS object with the following supported properties:

- expirationTime
- collapseID
- topic

Don't hesitate to feedback on the code as JS isn't my "native" language :)