### PR TITLE
Ensured that raw aps data is correctly parsed

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -188,6 +188,39 @@ describe('APNS', () => {
     expect(notification.collapseId).toEqual(collapseId);
     done();
   });
+  
+    it('can generate APNS notification from raw data', (done) => {
+      //Mock request data
+      let data = {
+        'aps': {
+          'alert': {
+            "loc-key" : "GAME_PLAY_REQUEST_FORMAT",
+            "loc-args" : [ "Jenna", "Frank"]
+          },
+          'badge': 100,
+          'sound': 'test'
+        },
+        'key': 'value',
+        'keyAgain': 'valueAgain'
+      };
+      let expirationTime = 1454571491354;
+      let collapseId = "collapseIdentifier";
+  
+      let notification = APNS._generateNotification(data, { expirationTime: expirationTime, collapseId: collapseId });
+  
+      expect(notification.expiry).toEqual(expirationTime / 1000);
+      expect(notification.collapseId).toEqual(collapseId);
+  
+      let stringifiedJSON = notification.compile();
+      let jsonObject = JSON.parse(stringifiedJSON);
+  
+      expect(jsonObject.aps.alert).toEqual({ "loc-key" : "GAME_PLAY_REQUEST_FORMAT", "loc-args" : [ "Jenna", "Frank"] });
+      expect(jsonObject.aps.badge).toEqual(100);
+      expect(jsonObject.aps.sound).toEqual('test');
+      expect(jsonObject.key).toEqual('value');
+      expect(jsonObject.keyAgain).toEqual('valueAgain');
+      done();
+    });
 
   it('can choose providers for device with valid appIdentifier', (done) => {
     let appIdentifier = 'topic';

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -174,6 +174,9 @@ export class APNS {
     let payload = {};
     for (let key in coreData) {
       switch (key) {
+        case 'aps':
+          notification.aps = coreData.aps;
+          break;
         case 'alert':
           notification.setAlert(coreData.alert);
           break;


### PR DESCRIPTION
This change ensures that the dashboard will support the following JSON payload:
```
{
    "aps" : {
        "alert" : {
            "title" : "Game Request",
            "body" : "Bob wants to play poker",
            "action-loc-key" : "PLAY"
        },
        "badge" : 5
    },
    "acme1" : "bar",
    "acme2" : [ "bang",  "whiz" ]
}
```
or this one:
```
{
    "aps" : {
        "alert" : {
            "loc-key" : "GAME_PLAY_REQUEST_FORMAT",
            "loc-args" : [ "Jenna", "Frank"]
        },
        "sound" : "chime.aiff"
    },
    "acme" : "foo"
}
```

This is a more advanced way of sending aps data, sure, but this ensures that current and future unsupported keys will continue to work.